### PR TITLE
Save/Restore nightmode in localstorage, for app users who always prefer dark mode

### DIFF
--- a/js/nightmode.js
+++ b/js/nightmode.js
@@ -1,14 +1,26 @@
+function toggleNightMode() {
+  if (document.getElementsByTagName("html")[0].style.backgroundColor === "rgb(45, 48, 44)") {
+    document.getElementsByTagName("html")[0].style.backgroundColor = "#faf8ef";
+    document.getElementsByTagName("body")[0].style.backgroundColor = "#faf8ef";
+    if (typeof(Storage) !== "undefined") {
+      localStorage['nightmode'] = "0";
+    }
+    return false;
+  } else {
+    document.getElementsByTagName("html")[0].style.backgroundColor = "#2D302C";
+    document.getElementsByTagName("body")[0].style.backgroundColor = "#2D302C";
+    if (typeof(Storage) !== "undefined") {
+      localStorage['nightmode'] = "1";
+    }
+    return false;
+  }
+}
+
 window.onload = function() {
   var a = document.getElementById("night");
-  a.onclick = function() {
-   	if (document.getElementsByTagName("html")[0].style.backgroundColor === "rgb(45, 48, 44)") {
-   		document.getElementsByTagName("html")[0].style.backgroundColor = "#faf8ef";
-   		document.getElementsByTagName("body")[0].style.backgroundColor = "#faf8ef";
-     	return false;
-    } else {
-   		document.getElementsByTagName("html")[0].style.backgroundColor = "#2D302C";
-   		document.getElementsByTagName("body")[0].style.backgroundColor = "#2D302C";
-  		return false;
-    }
+  a.onclick = toggleNightMode;
+
+  if (typeof(Storage) !== "undefined" && localStorage['nightmode'] == "1") {
+    toggleNightMode();
   }
 }


### PR DESCRIPTION
Save/Restore nightmode in localstorage, for app users who always prefer dark mode

When using 2048 on phones you always have to press the nightmode button over and over when you start a game again. (aand it's 50/50 chance of hit chance :P #8 ).

Wit this change, use localStorage to preserve the nightmode state, and restore when coming to the app again.