### PR TITLE
german translation

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -60,13 +60,13 @@ var Localizer = (function(lang) {
 		localizedMsgs = {
 			intro : 'Verbinde Zahlen &amp; schaffe die <strong>2048 Kachel!</strong>',
 			new_game : 'Neues Spiel',
-			undo : 'R&uuml;ckg&auml;ngig',
+			undo : 'R&uuml;ck.',
 			keep_going : 'Weitermachen',
 			try_again : 'Erneut versuchen',
 			ok : 'OK',
 			cancel : 'Abbrechen',
 			start_a_new_game : 'Neues Spiel beginnen?',
-			undo_the_current_move : 'Zug r&uuml;ckg&auml;ngig machen?',
+			undo_the_current_move : 'Zug rückgängig machen?',
 			you_win : 'Sieg!',
 			game_over : 'Game over!'
 		};

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -23,7 +23,7 @@ var Localizer = (function(lang) {
 
 	var localizedMsgs = {};
 
-	this.lang = lang || 'en';
+	this.lang = lang || navigator.language || 'en';
 
 	switch (this.lang) {
 	case 'ru':

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -56,6 +56,21 @@ var Localizer = (function(lang) {
 			game_over : 'Гра завершена!'
 		};
 		break;
+	case 'de':
+		localizedMsgs = {
+			intro : 'Verbinde Zahlen &amp; schaffe die <strong>2048 Kachel!</strong>',
+			new_game : 'Neues Spiel',
+			undo : 'R&uuml;ckg&auml;ngig',
+			keep_going : 'Weitermachen',
+			try_again : 'Erneut versuchen',
+			ok : 'OK',
+			cancel : 'Abbrechen',
+			start_a_new_game : 'Neues Spiel beginnen?',
+			undo_the_current_move : 'Zug r&uuml;ckg&auml;ngig machen?',
+			you_win : 'Sieg!',
+			game_over : 'Game over!'
+		};
+		break;
 	}
 
 	// In Android (ES5 and earlier) we can not use Object.assign method


### PR DESCRIPTION
Add german translation

checked if it works length wise, initial try was too long (multiline where shouldn't etc).


![Screenshot_20191201-212911](https://user-images.githubusercontent.com/6735650/69919856-5ea9b500-1479-11ea-9063-018565f098c9.png)

![Screenshot_20191201-212916](https://user-images.githubusercontent.com/6735650/69919858-60737880-1479-11ea-94ba-75891cb9162d.png)


also, when no language specified try to use browser language (when available) - english stays default&fallback of course.